### PR TITLE
adds ConsumeErrHandler

### DIFF
--- a/service.go
+++ b/service.go
@@ -312,9 +312,9 @@ func (n *NATSJSEventSource) StartEventSource(src *proto.EventSource, svr proto.E
 
 	errChan := make(chan error, 1)
 	errHandler := func(consumeCtx jetstream.ConsumeContext, err error) {
-		if err == jetstream.ErrConsumerDeleted || err == jetstream.ErrStreamNotFound {
+		if errors.Is(err, jetstream.ErrConsumerDeleted) || errors.Is(err, jetstream.ErrStreamNotFound) {
 			consumeCtx.Stop()
-			errChan <- err
+			errChan <- logErr(fmt.Errorf("Consumer error: %w", err))
 		}
 	}
 
@@ -350,7 +350,7 @@ func (n *NATSJSEventSource) StartEventSource(src *proto.EventSource, svr proto.E
 	select {
 	case <-ctx.Done():
 		return consumerErr
-	case err:= <-errChan:
+	case err := <-errChan:
 		return err
 	}
 

--- a/service.go
+++ b/service.go
@@ -310,7 +310,15 @@ func (n *NATSJSEventSource) StartEventSource(src *proto.EventSource, svr proto.E
 		}
 	}
 
-	consumerCtx, err := consumer.Consume(handler)
+	errChan := make(chan error, 1)
+	errHandler := func(consumeCtx jetstream.ConsumeContext, err error) {
+		if err == jetstream.ErrConsumerDeleted || err == jetstream.ErrStreamNotFound {
+			consumeCtx.Stop()
+			errChan <- err
+		}
+	}
+
+	consumerCtx, err := consumer.Consume(handler, jetstream.ConsumeErrHandler(errHandler))
 	if err != nil {
 		return logErr(fmt.Errorf("error consuming messages: %w", err))
 	}
@@ -333,14 +341,19 @@ func (n *NATSJSEventSource) StartEventSource(src *proto.EventSource, svr proto.E
 			return
 		}
 		consumerCtx.Stop()
-		consumerCtx, err = consumer.Consume(handler)
+		consumerCtx, err = consumer.Consume(handler, jetstream.ConsumeErrHandler(errHandler))
 		if err != nil {
 			consumerErr = logErr(fmt.Errorf("error consuming messages: %w", err))
 		}
 	}
 
-	<-ctx.Done()
-	return consumerErr
+	select {
+	case <-ctx.Done():
+		return consumerErr
+	case err:= <-errChan:
+		return err
+	}
+
 }
 
 func (n *NATSJSEventSource) addTLSOptions(cfg *NATSJSEventSourceCfg, opt *[]nats.Option) error {


### PR DESCRIPTION
Adds a  `ConsumeErrHandler`,  and bubbles up related errors.
This triggers a reconnect/recreate on a deleted live consumer

addresses #2